### PR TITLE
Fix section detection: decimal number false positives and header/body…

### DIFF
--- a/clinspacy/parse.py
+++ b/clinspacy/parse.py
@@ -125,12 +125,12 @@ def parse_section(
         )
     elif section_metadata.section_mention_type == "Numeric":
         patterns.append(
-            {"REGEX_TEXT": re.compile(r"^.{0,21}\b(\d+)[.:)]", re.MULTILINE)}
+            {"REGEX_TEXT": re.compile(r"^.{0,21}\b(\d+)[.:)](?!\d)", re.MULTILINE)}
         )
     elif section_metadata.section_mention_type == "AlphaNumeric":
         # Supports both alphabetic (A., B.) and numeric (1., 2.) specimen sections
         patterns.append(
-            {"REGEX_TEXT": re.compile(r"^.{0,21}\b([A-Z]|\d+)[.:)]", re.MULTILINE)}
+            {"REGEX_TEXT": re.compile(r"^.{0,21}\b([A-Z]|\d+)[.:)](?!\d)", re.MULTILINE)}
         )
     elif section_metadata.section_mention_type == "Token":
         with nlp.select_pipes(enable=["tagger", "attribute_ruler", "lemmatizer"]):

--- a/clinspacy/segment.py
+++ b/clinspacy/segment.py
@@ -76,10 +76,18 @@ class Sectionizer:
                     section_headers.append(doc[start:end])
                     section_header_names.append(name)
 
-        sorted_section_headers = sorted(section_headers, key=lambda s: s.start)
-        for idx, span in enumerate(sorted_section_headers):
-            if idx + 1 < len(sorted_section_headers):
-                end = sorted_section_headers[idx + 1].start
+        paired = sorted(zip(section_headers, section_header_names), key=lambda p: p[0].start)
+        doc.spans["section_headers"] = []
+        doc.spans["section_headers"].attrs["names"] = []
+        section_headers = doc.spans["section_headers"]
+        section_header_names = doc.spans["section_headers"].attrs["names"]
+        for span, name in paired:
+            section_headers.append(span)
+            section_header_names.append(name)
+
+        for idx, span in enumerate(section_headers):
+            if idx + 1 < len(section_headers):
+                end = section_headers[idx + 1].start
             else:
                 end = len(doc)
             end = self.find_section_break(doc, span.start, end)


### PR DESCRIPTION
… mismatch.

Add (?!\d) lookahead to Numeric and AlphaNumeric section regexes so decimal numbers like "1.5 cm" are not mistaken for section markers (e.g. "1." captured as a specimen header from "Tumor Size: 1.5 cm").

Sort section_headers and section_header_names together before building section bodies. Previously only a local copy was sorted, leaving doc.spans["section_headers"] in discovery order while sections were in position order. When multiple section types (Token + AlphaNumeric) contributed headers, extract_sections paired them by index and produced detached header/body ranges.