### PR TITLE
Fix value-type schemas with same value overwriting each other in doc.s…

### DIFF
--- a/clinspacy/abstract.py
+++ b/clinspacy/abstract.py
@@ -81,7 +81,7 @@ def apply_nlp(request: SuggestRequest) -> Doc:
                 abstractor.span_ruler.add(name_patterns["predicate"], name_patterns)
             else:
                 for vp in value_patterns:
-                    abstractor.span_ruler.add(vp["value"], vp)
+                    abstractor.span_ruler.add(f"{vp['predicate']}:{vp['value']}", vp)
         yield abstractor.nlp(request.text)
     finally:
         pass


### PR DESCRIPTION
…pans.

When multiple schemas had value-type patterns sharing the same value name, they used that value as the doc.spans key, causing the second to overwrite the first. Include the predicate in the key to ensure uniqueness.